### PR TITLE
Fixed AttributeError exception

### DIFF
--- a/netio-exporter.py
+++ b/netio-exporter.py
@@ -135,7 +135,7 @@ class NetioCollector:
             # in cobra, there is a `mac` field instead of the `SerialNumber` field
             'sn': (self.data.get('Agent', {}).get('SerialNumber') or
                    self.data.get('Agent', {}).get('MAC')) or
-                  "Unknown",
+                  'Unknown',
             'target': self.args.url
         })
         logger.debug(info)

--- a/netio-exporter.py
+++ b/netio-exporter.py
@@ -132,7 +132,7 @@ class NetioCollector:
             'json_version': self.data.get('Agent', {}).get('JSONVer'),
             'name': self.data.get('Agent', {}).get('DeviceName'),
             'outputs': str(self.data.get('Agent', {}).get('NumOutputs')),
-            # in cobra, there is a `mac` field instead of the `SerialNumber` field
+            # in cobra, there is a `mac` field instead of the `SerialNumber` field. There are also some 4Cs, that have `SerialNumber` empty.
             'sn': (self.data.get('Agent', {}).get('SerialNumber') or
                    self.data.get('Agent', {}).get('MAC')) or
                   'Unknown',

--- a/netio-exporter.py
+++ b/netio-exporter.py
@@ -134,9 +134,11 @@ class NetioCollector:
             'outputs': str(self.data.get('Agent', {}).get('NumOutputs')),
             # in cobra, there is a `mac` field instead of the `SerialNumber` field
             'sn': (self.data.get('Agent', {}).get('SerialNumber') or
-                   self.data.get('Agent', {}).get('MAC')),
+                   self.data.get('Agent', {}).get('MAC')) or
+                  "Unknown",
             'target': self.args.url
         })
+        logger.debug(info)
         self.metrics.append(info)
 
     def process_global(self):

--- a/netio-exporter.py
+++ b/netio-exporter.py
@@ -138,7 +138,7 @@ class NetioCollector:
                   'Unknown',
             'target': self.args.url
         })
-        logger.debug(info)
+        logger.debug(f'Agent info metric: {info}')
         self.metrics.append(info)
 
     def process_global(self):


### PR DESCRIPTION
When SerialNumber can't be addressed (dunno the cause), having an empty value (Null) will result in 500 error once scraping.